### PR TITLE
Invoke clearDFA to save memory

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/parser/ConcurrentSqlParser.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/ConcurrentSqlParser.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.parser;
+
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.dfa.DFA;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ConcurrentSqlParser
+        extends SqlBaseParser
+{
+    private static final AtomicReference<PredictionContextCache> predictionContextCache = new AtomicReference<>(new PredictionContextCache());
+    private static final AtomicReference<DFA[]> decisionToDFA = new AtomicReference<>(Arrays.copyOf(_decisionToDFA, _decisionToDFA.length));
+    private static final AtomicLong invocationCount = new AtomicLong();
+
+    public ConcurrentSqlParser(TokenStream input)
+    {
+        super(input);
+        if (invocationCount.incrementAndGet() % 10000 == 0) { // is it too often?
+            clear();
+        }
+        _interp = new ParserATNSimulator(this, this.getATN(), decisionToDFA.get(), predictionContextCache.get());
+    }
+
+    private static void clear()
+    {
+        synchronized (decisionToDFA) {
+            for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
+                _decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
+            }
+            predictionContextCache.set(new PredictionContextCache());
+            decisionToDFA.set(Arrays.copyOf(_decisionToDFA, _decisionToDFA.length));
+        }
+    }
+}

--- a/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/SqlParser.java
@@ -121,7 +121,7 @@ public class SqlParser
         try {
             SqlBaseLexer lexer = new SqlBaseLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-            SqlBaseParser parser = new SqlBaseParser(tokenStream);
+            SqlBaseParser parser = new ConcurrentSqlParser(tokenStream);
 
             // Override the default error strategy to not attempt inserting or deleting a token.
             // Otherwise, it messes up error reporting


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/4229

revive calling clearDFA

* technically just calling `clearDFA` has mutual update issue. As it update `_decisionToDFA[]` element but another thread can access `_decisionToDFA[]` during it's being updated. 
* `predictionContextCache` could occupy large hash-table entries. But `clearDFA` doesn't reset it. I got the idea from http://stackoverflow.com/questions/28724334/antlr4-memory-cleanup 