### PR TITLE
Catch Errors also at getting LocalDispatchQuery QueryException

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalDispatchQuery.java
@@ -266,7 +266,7 @@ public class LocalDispatchQuery
         try {
             return tryGetFutureValue(queryExecutionFuture);
         }
-        catch (Exception ignored) {
+        catch (Throwable ignored) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
Prevent `StackOverflowError` stopping `DispatchManager.getQueries`