### PR TITLE
Backport approx_most_frequent function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1131,6 +1131,18 @@
                 <artifactId>javassist</artifactId>
                 <version>3.22.0-GA</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.clearspring.analytics</groupId>
+                <artifactId>stream</artifactId>
+                <version>2.9.5</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>it.unimi.dsi</groupId>
+                        <artifactId>fastutil</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -302,6 +302,11 @@
             <artifactId>jjwt</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.clearspring.analytics</groupId>
+            <artifactId>stream</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -29,6 +29,7 @@ import io.prestosql.operator.aggregation.ApproximateDoublePercentileAggregations
 import io.prestosql.operator.aggregation.ApproximateDoublePercentileArrayAggregations;
 import io.prestosql.operator.aggregation.ApproximateLongPercentileAggregations;
 import io.prestosql.operator.aggregation.ApproximateLongPercentileArrayAggregations;
+import io.prestosql.operator.aggregation.ApproximateMostFrequentFunction;
 import io.prestosql.operator.aggregation.ApproximateRealPercentileAggregations;
 import io.prestosql.operator.aggregation.ApproximateRealPercentileArrayAggregations;
 import io.prestosql.operator.aggregation.ApproximateSetAggregation;
@@ -639,7 +640,8 @@ public class FunctionRegistry
                 .aggregate(BuildSetDigestAggregation.class)
                 .scalars(SetDigestFunctions.class)
                 .scalars(SetDigestOperators.class)
-                .scalars(WilsonInterval.class);
+                .scalars(WilsonInterval.class)
+                .aggregate(ApproximateMostFrequentFunction.class);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketDeserializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketDeserializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.SliceInput;
+
+public interface ApproximateMostFrequentBucketDeserializer<K>
+{
+    void deserialize(SliceInput input, ApproximateMostFrequentHistogram<K> histogram);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentBucketSerializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+
+public interface ApproximateMostFrequentBucketSerializer<K>
+{
+    public void serialize(K key, Long count, DynamicSliceOutput output);
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentFunction.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateMetadata;
+import io.prestosql.spi.function.AggregationFunction;
+import io.prestosql.spi.function.AggregationState;
+import io.prestosql.spi.function.CombineFunction;
+import io.prestosql.spi.function.InputFunction;
+import io.prestosql.spi.function.OutputFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.function.TypeParameter;
+import io.prestosql.spi.type.BigintType;
+import io.prestosql.spi.type.VarcharType;
+
+import java.util.Map;
+
+import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.prestosql.spi.type.StandardTypes.BIGINT;
+import static io.prestosql.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
+
+/**
+ *  Aggregation function that approximates the frequency of the top-K elements.
+ *  This function keeps counts for a "frequent" subset of elements and assumes all other elements
+ *  once fewer than the least-frequent "frequent" element.
+ *
+ *   The algorithm is based loosely on:
+ *   .. code-block:: none
+ *   Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi,
+ *  "Efficient Computation of Frequent and Top-*k* Elements in Data Streams",
+ *  https://dl.acm.org/doi/10.1007/978-3-540-30570-5_27
+ */
+@AggregationFunction("approx_most_frequent")
+public final class ApproximateMostFrequentFunction
+{
+    private ApproximateMostFrequentFunction() {}
+
+    public interface State<K>
+            extends AccumulatorState
+    {
+        ApproximateMostFrequentHistogram<K> get();
+
+        void set(ApproximateMostFrequentHistogram<K> value);
+    }
+
+    @AccumulatorStateMetadata(stateSerializerClass = LongApproximateMostFrequentStateSerializer.class, stateFactoryClass = LongApproximateMostFrequentStateFactory.class)
+    public interface LongState
+            extends State<Long>
+    {}
+
+    @AccumulatorStateMetadata(stateSerializerClass = StringApproximateMostFrequentStateSerializer.class, stateFactoryClass = StringApproximateMostFrequentStateFactory.class)
+    public interface StringState
+            extends State<String>
+    {}
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState LongState state, @SqlType(BIGINT) long buckets, @SqlType("T") long value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<Long>(toIntExact(buckets), toIntExact(capacity),
+                    LongApproximateMostFrequentStateSerializer::serializeBucket,
+                    LongApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState StringState state, @SqlType(BIGINT) long buckets, @SqlType("T") Slice value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<String> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<String>(toIntExact(buckets), toIntExact(capacity),
+                    StringApproximateMostFrequentStateSerializer::serializeBucket,
+                    StringApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value.toStringUtf8());
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState LongState state, @AggregationState LongState otherState)
+    {
+        ApproximateMostFrequentHistogram<Long> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState StringState state, @AggregationState StringState otherState)
+    {
+        ApproximateMostFrequentHistogram<String> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<String> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @OutputFunction("map(T,bigint)")
+    public static void output(@AggregationState LongState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            Map<Long, Long> value = state.get().getBuckets();
+
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            for (Map.Entry<Long, Long> entry : value.entrySet()) {
+                BigintType.BIGINT.writeLong(entryBuilder, entry.getKey());
+                BigintType.BIGINT.writeLong(entryBuilder, entry.getValue());
+            }
+            out.closeEntry();
+        }
+    }
+
+    @OutputFunction("map(T,bigint)")
+    public static void output(@AggregationState StringState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            Map<String, Long> value = state.get().getBuckets();
+
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            for (Map.Entry<String, Long> entry : value.entrySet()) {
+                VarcharType.VARCHAR.writeSlice(entryBuilder, Slices.utf8Slice(entry.getKey()));
+                BigintType.BIGINT.writeLong(entryBuilder, entry.getValue());
+            }
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentHistogram.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateMostFrequentHistogram.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import com.clearspring.analytics.stream.Counter;
+import com.clearspring.analytics.stream.StreamSummary;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ *  Calculate the histogram approximately for topk elements based on the
+ *  <i>Space-Saving</i> algorithm and the <i>Stream-Summary</i> data structure
+ *  as described in:
+ *  <i>Efficient Computation of Frequent and Top-k Elements in Data Streams</i>
+ *  by Metwally, Agrawal, and Abbadi
+ * @param <K>
+ */
+public class ApproximateMostFrequentHistogram<K>
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ApproximateMostFrequentHistogram.class).instanceSize();
+    // Larger capacity for stream summary improves the accuracy.
+    private static final int MAX_CAPACITY_FACTOR = 5;
+
+    private StreamSummary<K> streamSummary;
+    private int maxBuckets;
+    private int capacity;
+    private ApproximateMostFrequentBucketSerializer<K> serializer;
+    private ApproximateMostFrequentBucketDeserializer<K> deserializer;
+
+    /**
+     * @param maxBuckets The maximum number of elements stored in the bucket.
+     * @param capacity The maximum capacity of the stream summary data structure.
+     * @param serializer It serializes a bucket into varbinary slice.
+     * @param deserializer It appends a bucket into the histogram.
+     */
+    public ApproximateMostFrequentHistogram(int maxBuckets,
+                                            int capacity,
+                                            ApproximateMostFrequentBucketSerializer<K> serializer,
+                                            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        requireNonNull(serializer, "serializer is null");
+        requireNonNull(deserializer, "deserializer is null");
+        streamSummary = new StreamSummary<>(capacity);
+        this.maxBuckets = maxBuckets;
+        this.capacity = capacity;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
+
+    public ApproximateMostFrequentHistogram(Slice serialized,
+                                            ApproximateMostFrequentBucketSerializer<K> serializer,
+                                            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        SliceInput input = serialized.getInput();
+
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+
+        this.maxBuckets = input.readInt();
+        this.capacity = input.readInt();
+        this.streamSummary = new StreamSummary<>(capacity);
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+
+        for (int i = 0; i < maxBuckets; i++) {
+            this.deserializer.deserialize(input, this);
+        }
+    }
+
+    public void add(K value)
+    {
+        streamSummary.offer(value);
+    }
+
+    public void add(K value, long incrementCount)
+    {
+        streamSummary.offer(value, toIntExact(incrementCount));
+    }
+
+    public Slice serialize()
+    {
+        DynamicSliceOutput output = new DynamicSliceOutput(1000);
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        output.appendByte(FORMAT_TAG);
+        output.appendInt(maxBuckets);
+        output.appendInt(capacity);
+        // Serialize key and counts.
+        for (Counter<K> counter : counters) {
+            serializer.serialize(counter.getItem(), counter.getCount(), output);
+        }
+
+        return output.getUnderlyingSlice();
+    }
+
+    public void merge(ApproximateMostFrequentHistogram<K> other)
+    {
+        List<Counter<K>> counters = other.streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            add(counter.getItem(), counter.getCount());
+        }
+    }
+
+    public Map<K, Long> getBuckets()
+    {
+        ImmutableMap.Builder<K, Long> buckets = new ImmutableMap.Builder<>();
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            buckets.put(counter.getItem(), counter.getCount());
+        }
+
+        return buckets.build();
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.prestosql.array.ObjectBigArray;
+import io.prestosql.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateFactory;
+
+public class LongApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<ApproximateMostFrequentFunction.LongState>
+{
+    @Override
+    public ApproximateMostFrequentFunction.LongState createSingleState()
+    {
+        return new SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.LongState> getSingleStateClass()
+    {
+        return SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public ApproximateMostFrequentFunction.LongState createGroupedState()
+    {
+        return new GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.LongState> getGroupedStateClass()
+    {
+        return GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements ApproximateMostFrequentFunction.LongState
+    {
+        private ApproximateMostFrequentHistogram<Long> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            this.histogram = histogram;
+            size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements ApproximateMostFrequentFunction.LongState
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<Long>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            ApproximateMostFrequentHistogram<Long> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            size += histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/LongApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorStateSerializer;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+
+public class LongApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<ApproximateMostFrequentFunction.LongState>
+{
+    public static void serializeBucket(Long key, Long count, DynamicSliceOutput output)
+    {
+        output.appendLong(key);
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<Long> histogram)
+    {
+        Long key = input.readLong();
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(ApproximateMostFrequentFunction.LongState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ApproximateMostFrequentFunction.LongState state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<Long>(VARBINARY.getSlice(block, index),
+                LongApproximateMostFrequentStateSerializer::serializeBucket,
+                LongApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.prestosql.array.ObjectBigArray;
+import io.prestosql.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import io.prestosql.spi.function.AccumulatorStateFactory;
+
+public class StringApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<ApproximateMostFrequentFunction.StringState>
+{
+    @Override
+    public ApproximateMostFrequentFunction.StringState createSingleState()
+    {
+        return new StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.StringState> getSingleStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public ApproximateMostFrequentFunction.StringState createGroupedState()
+    {
+        return new StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends ApproximateMostFrequentFunction.StringState> getGroupedStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements ApproximateMostFrequentFunction.StringState
+    {
+        private ApproximateMostFrequentHistogram<String> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<String> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<String> histogram)
+        {
+            this.histogram = histogram;
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements ApproximateMostFrequentFunction.StringState
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<String>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<String> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<String> histogram)
+        {
+            ApproximateMostFrequentHistogram<String> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/StringApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.function.AccumulatorStateSerializer;
+import io.prestosql.spi.type.Type;
+
+import static io.prestosql.spi.type.VarbinaryType.VARBINARY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class StringApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<ApproximateMostFrequentFunction.StringState>
+{
+    public static void serializeBucket(String key, Long count, DynamicSliceOutput output)
+    {
+        byte[] keyBytes = key.getBytes(UTF_8);
+        output.appendInt(keyBytes.length);
+        output.appendBytes(key.getBytes(UTF_8));
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<String> histogram)
+    {
+        int keySize = input.readInt();
+        String key = input.readSlice(keySize).toStringUtf8();
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(ApproximateMostFrequentFunction.StringState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ApproximateMostFrequentFunction.StringState state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<String>(VARBINARY.getSlice(block, index),
+                StringApproximateMostFrequentStateSerializer::serializeBucket,
+                StringApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximateMostFrequentHistogram.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximateMostFrequentHistogram.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.aggregation;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestApproximateMostFrequentHistogram
+{
+    @Test
+    public void testLongHistogram()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add(1L);
+        histogram.add(1L);
+        histogram.add(2L);
+        histogram.add(3L);
+        histogram.add(4L);
+
+        Map<Long, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testLongRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<Long> original = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add(1L);
+        original.add(1L);
+        original.add(2L);
+        original.add(3L);
+        original.add(4L);
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<Long> deserialized = new ApproximateMostFrequentHistogram<Long>(serialized, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+
+    @Test
+    public void testMerge()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram1 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram1.add(1L);
+        histogram1.add(1L);
+        histogram1.add(2L);
+
+        ApproximateMostFrequentHistogram<Long> histogram2 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+        histogram2.add(3L);
+        histogram2.add(4L);
+
+        histogram1.merge(histogram2);
+        Map<Long, Long> buckets = histogram1.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testStringHistogram()
+    {
+        ApproximateMostFrequentHistogram<String> histogram = new ApproximateMostFrequentHistogram<String>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add("A");
+        histogram.add("A");
+        histogram.add("B");
+        histogram.add("C");
+        histogram.add("D");
+
+        Map<String, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of("A", 2L, "B", 1L, "C", 1L));
+    }
+
+    @Test
+    public void testStringRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<String> original = new ApproximateMostFrequentHistogram<String>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add("A");
+        original.add("A");
+        original.add("B");
+        original.add("C");
+        original.add("D");
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<String> deserialized = new ApproximateMostFrequentHistogram<String>(serialized, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+}

--- a/presto-phoenix/pom.xml
+++ b/presto-phoenix/pom.xml
@@ -296,6 +296,12 @@
                         <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
                         <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
                     </ignoredResourcePatterns>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>com.clearspring.analytics</groupId>
+                            <artifactId>stream</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestAggregations.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.tests;
 
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.MaterializedRow;
 import org.testng.annotations.Test;
@@ -1274,5 +1275,29 @@ public abstract class AbstractTestAggregations
     public void testAggregationWithConstantArgumentsOverScalar()
     {
         assertQuery("SELECT count(1) FROM (SELECT count(custkey) FROM orders LIMIT 10) a");
+    }
+
+    @Test
+    public void testApproxMostFrequentWithLong()
+    {
+        MaterializedResult actual1 = computeActual("SELECT approx_most_frequent(3, cast(x as bigint), 15) FROM (values 1, 2, 1, 3, 1, 2, 3, 4, 5) t(x)");
+        assertEquals(actual1.getRowCount(), 1);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of(1L, 3L, 2L, 2L, 3L, 2L));
+
+        MaterializedResult actual2 = computeActual("SELECT approx_most_frequent(2, cast(x as bigint), 15) FROM (values 1, 2, 1, 3, 1, 2, 3, 4, 5) t(x)");
+        assertEquals(actual2.getRowCount(), 1);
+        assertEquals(actual2.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of(1L, 3L, 2L, 2L));
+    }
+
+    @Test
+    public void testApproxMostFrequentWithVarchar()
+    {
+        MaterializedResult actual1 = computeActual("SELECT approx_most_frequent(3, x, 15) FROM (values 'A', 'B', 'A', 'C', 'A', 'B', 'C', 'D', 'E') t(x)");
+        assertEquals(actual1.getRowCount(), 1);
+        assertEquals(actual1.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of("A", 3L, "B", 2L, "C", 2L));
+
+        MaterializedResult actual2 = computeActual("SELECT approx_most_frequent(2, x, 15) FROM (values 'A', 'B', 'A', 'C', 'A', 'B', 'C', 'D', 'E') t(x)");
+        assertEquals(actual2.getRowCount(), 1);
+        assertEquals(actual2.getMaterializedRows().get(0).getFields().get(0), ImmutableMap.of("A", 3L, "B", 2L));
     }
 }


### PR DESCRIPTION
Since it is not possible to implement the aggregation function in the plugin side due to the class loader issue, we add the function in the forked repository as backporting.