### PR TITLE
MPP-3268: Backport TypeCoercioin.isCompatible

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -373,7 +373,7 @@ class StatementAnalyzer
             }
 
             for (int i = 0; i < tableTypes.size(); i++) {
-                if (!typeCoercion.canCoerce(queryTypes.get(i), tableTypes.get(i))) {
+                if (!typeCoercion.isCompatible(queryTypes.get(i), tableTypes.get(i))) {
                     return false;
                 }
             }

--- a/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
+++ b/presto-main/src/main/java/io/prestosql/type/TypeCoercion.java
@@ -112,6 +112,12 @@ public final class TypeCoercion
         return Optional.of(compatibility.getCommonSuperType());
     }
 
+    public boolean isCompatible(Type fromType, Type toType)
+    {
+        TypeCompatibility typeCompatibility = compatibility(fromType, toType);
+        return typeCompatibility.isCompatible();
+    }
+
     public boolean canCoerce(Type fromType, Type toType)
     {
         TypeCompatibility typeCompatibility = compatibility(fromType, toType);


### PR DESCRIPTION
We need a 317's fix to suport insert `char(N)` to `varchar` column, https://github.com/prestosql/presto/commit/29db89635998c0bcd3d82213e5eae71130ffbc67 
But it depends several previous commits, I only copy required change for now