### PR TITLE
MPP-3183: Support JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.183</dep.airlift.version>
+        <dep.airlift.version>0.183.5</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.36</dep.slice.version>
         <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
@@ -1266,6 +1266,17 @@
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>treasuredata</id>
+            <name>treasuredata-releases</name>
+            <url>https://treasuredata.jfrog.io/treasuredata/libs-release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <profiles>
         <profile>

--- a/presto-main/src/main/java/io/prestosql/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/io/prestosql/server/PrestoSystemRequirements.java
@@ -14,6 +14,7 @@
 package io.prestosql.server;
 
 import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.joda.time.DateTime;
@@ -71,10 +72,13 @@ final class PrestoSystemRequirements
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
-            if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
-                failRequirement("Presto requires amd64 or ppc64le on Linux (found %s)", osArch);
+            if (!ImmutableSet.of("amd64", "aarch64", "ppc64le").contains(osArch)) {
+                failRequirement("Presto requires amd64, aarch64, or ppc64le on Linux (found %s)", osArch);
             }
-            if ("ppc64le".equals(osArch)) {
+            if ("aarch64".equals(osArch)) {
+                warnRequirement("Support for the ARM architecture is experimental");
+            }
+            else if ("ppc64le".equals(osArch)) {
                 warnRequirement("Support for the POWER architecture is experimental");
             }
         }


### PR DESCRIPTION
## Working branches

- https://github.com/treasure-data/td-presto/tree/MPP-3183-jdk11a
- ~~https://github.com/treasure-data/td-presto/tree/MPP-3183-jdk11~~
- https://github.com/treasure-data/td-presto/tree/graviton2

----
I made a mistake.
https://github.com/prestosql/presto/pull/3791