### PR TITLE
Add missing timezone for java11

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ EXCLUDE_MODULES = %w|
  presto-raptor-legacy
  presto-mysql
  presto-sqlserver
+ presto-kafka
  presto-kudu
  presto-server-rpm
 |

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>
-        <dep.joda.version>2.10</dep.joda.version>
+        <dep.joda.version>2.10.6</dep.joda.version>
         <dep.tempto.version>165</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestGeoFunctions.java
@@ -811,9 +811,9 @@ public class TestGeoFunctions
     @Test
     public void testGreatCircleDistance()
     {
-        assertFunction("great_circle_distance(36.12, -86.67, 33.94, -118.40)", DOUBLE, 2886.448973436703);
-        assertFunction("great_circle_distance(33.94, -118.40, 36.12, -86.67)", DOUBLE, 2886.448973436703);
-        assertFunction("great_circle_distance(42.3601, -71.0589, 42.4430, -71.2290)", DOUBLE, 16.73469743457461);
+        assertFunction("great_circle_distance(36.12, -86.67, 33.94, -118.40)", DOUBLE, 2886.4489734367016);
+        assertFunction("great_circle_distance(33.94, -118.40, 36.12, -86.67)", DOUBLE, 2886.4489734367016);
+        assertFunction("great_circle_distance(42.3601, -71.0589, 42.4430, -71.2290)", DOUBLE, 16.73469743457383);
         assertFunction("great_circle_distance(36.12, -86.67, 36.12, -86.67)", DOUBLE, 0.0);
 
         assertInvalidFunction("great_circle_distance(100, 20, 30, 40)", "Latitude must be between -90 and 90");

--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -136,9 +136,9 @@ public class TestSphericalGeoFunctions
     @Test
     public void testDistance()
     {
-        assertDistance("POINT (-86.67 36.12)", "POINT (-118.40 33.94)", 2886448.973436703);
-        assertDistance("POINT (-118.40 33.94)", "POINT (-86.67 36.12)", 2886448.973436703);
-        assertDistance("POINT (-71.0589 42.3601)", "POINT (-71.2290 42.4430)", 16734.69743457461);
+        assertDistance("POINT (-86.67 36.12)", "POINT (-118.40 33.94)", 2886448.9734367016);
+        assertDistance("POINT (-118.40 33.94)", "POINT (-86.67 36.12)", 2886448.9734367016);
+        assertDistance("POINT (-71.0589 42.3601)", "POINT (-71.2290 42.4430)", 16734.69743457383);
         assertDistance("POINT (-86.67 36.12)", "POINT (-86.67 36.12)", 0.0);
 
         assertDistance("POINT EMPTY", "POINT (40 30)", null);

--- a/presto-spi/src/main/resources/io/prestosql/spi/type/zone-index.properties
+++ b/presto-spi/src/main/resources/io/prestosql/spi/type/zone-index.properties
@@ -2235,3 +2235,5 @@
 2226 Asia/Atyrau
 2227 Asia/Famagusta
 2228 Europe/Saratov
+2229 Asia/Qostanay
+2230 America/Nuuk

--- a/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
@@ -213,7 +213,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -4582158485614614451L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -3809591333307967388L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
This is a part of following commits. These are required to run tests on jdk11
* timezone  266423e2fca9987a02c3d834ce5d375931a9f104 and 7c6c31610a2324e08d9bacfa12747e3e68e28827 for jdk11 timezones
* geo-spacial tests 6bc60f30d033e9ae4255554afb8690344f8da5f4