### PR TITLE
Handle repeated expressions in QueryPlanner.coerce()

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
@@ -1340,7 +1340,7 @@ class QueryPlanner
         public PlanAndMappings(PlanBuilder subPlan, Map<NodeRef<Expression>, Symbol> mappings)
         {
             this.subPlan = subPlan;
-            this.mappings = mappings;
+            this.mappings = ImmutableMap.copyOf(mappings);
         }
 
         public PlanBuilder getSubPlan()

--- a/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
@@ -1120,24 +1120,27 @@ class QueryPlanner
         Assignments.Builder assignments = Assignments.builder();
         assignments.putIdentities(subPlan.getRoot().getOutputSymbols());
 
-        ImmutableMap.Builder<NodeRef<Expression>, Symbol> mappings = ImmutableMap.builder();
+        Map<NodeRef<Expression>, Symbol> mappings = new HashMap<>();
         for (Expression expression : expressions) {
             Type coercion = analysis.getCoercion(expression);
 
-            if (coercion != null) {
-                Type type = analysis.getType(expression);
-                Symbol symbol = symbolAllocator.newSymbol(expression, coercion);
+            // expressions may be repeated, for example, when resolving ordinal references in a GROUP BY clause
+            if (!mappings.containsKey(NodeRef.of(expression))) {
+                if (coercion != null) {
+                    Type type = analysis.getType(expression);
+                    Symbol symbol = symbolAllocator.newSymbol(expression, coercion);
 
-                assignments.put(symbol, new Cast(
-                        subPlan.rewrite(expression),
-                        toSqlType(coercion),
-                        false,
-                        typeCoercion.isTypeOnlyCoercion(type, coercion)));
+                    assignments.put(symbol, new Cast(
+                            subPlan.rewrite(expression),
+                            toSqlType(coercion),
+                            false,
+                            typeCoercion.isTypeOnlyCoercion(type, coercion)));
 
-                mappings.put(NodeRef.of(expression), symbol);
-            }
-            else {
-                mappings.put(NodeRef.of(expression), subPlan.translate(expression));
+                    mappings.put(NodeRef.of(expression), symbol);
+                }
+                else {
+                    mappings.put(NodeRef.of(expression), subPlan.translate(expression));
+                }
             }
         }
 
@@ -1147,7 +1150,7 @@ class QueryPlanner
                         subPlan.getRoot(),
                         assignments.build()));
 
-        return new PlanAndMappings(subPlan, mappings.build());
+        return new PlanAndMappings(subPlan, mappings);
     }
 
     public static Expression coerceIfNecessary(Analysis analysis, Expression original, Expression rewritten)

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestGroupBy.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestGroupBy.java
@@ -155,4 +155,12 @@ public class TestGroupBy
                         "GROUP BY t.A + 1"))
                 .matches("VALUES 2");
     }
+
+    @Test
+    public void testGroupByRepeatedOrdinals()
+    {
+        assertThat(assertions.query(
+                "SELECT null GROUP BY 1, 1"))
+                .matches("VALUES null");
+    }
 }


### PR DESCRIPTION
This can happen as a result of resolving repeated GROUP BY ordinals.