### PR TITLE
Implement shallowEquals for SampledRelation

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/tree/SampledRelation.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/SampledRelation.java
@@ -110,4 +110,15 @@ public class SampledRelation
     {
         return Objects.hash(relation, type, samplePercentage);
     }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        SampledRelation otherRelation = (SampledRelation) other;
+        return type == otherRelation.type && Objects.equals(samplePercentage, otherRelation.samplePercentage);
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/trinodb/trino/pull/10764