### PR TITLE
Include system memory to StatementStats

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -618,7 +618,7 @@ class Query
                 .setElapsedTimeMillis(queryStats.getElapsedTime().toMillis())
                 .setProcessedRows(queryStats.getRawInputPositions())
                 .setProcessedBytes(queryStats.getRawInputDataSize().toBytes())
-                .setPeakMemoryBytes(queryStats.getPeakUserMemoryReservation().toBytes())
+                .setPeakMemoryBytes(queryStats.getPeakTotalMemoryReservation().toBytes())
                 .setSpilledBytes(queryStats.getSpilledDataSize().toBytes())
                 .setRootStage(toStageStats(outputStage))
                 .build();


### PR DESCRIPTION
From Trino 369, it will not separate user and system memories https://github.com/trinodb/trino/pull/10574 . So it should be fine to include system memory to StatementStats as a workaround 