### PR TITLE
Fix unexpected predicate elimination in correlated subquery

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/EqualityInference.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Ordering;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.sql.tree.ComparisonExpression;
 import io.prestosql.sql.tree.Expression;
-import io.prestosql.sql.tree.SymbolReference;
 import io.prestosql.util.DisjointSet;
 
 import java.util.ArrayList;
@@ -322,16 +321,16 @@ public class EqualityInference
         }
 
         Collection<Expression> equivalences = equalitySets.get(canonicalIndex);
-        if (expression instanceof SymbolReference) {
-            boolean inScope = equivalences.stream()
-                    .filter(SymbolReference.class::isInstance)
-                    .map(Symbol::from)
-                    .anyMatch(symbolScope);
-
-            if (!inScope) {
-                return null;
-            }
-        }
+//        if (expression instanceof SymbolReference) {
+//            boolean inScope = equivalences.stream()
+//                    .filter(SymbolReference.class::isInstance)
+//                    .map(Symbol::from)
+//                    .anyMatch(symbolScope);
+//
+//            if (!inScope) {
+//                return null;
+//            }
+//        }
 
         Set<Expression> candidates = equivalences.stream()
                 .filter(e -> isScoped(e, symbolScope))


### PR DESCRIPTION
Revert https://github.com/trinodb/trino/pull/1550/files#diff-d5f6d85a278c69d6969856f07362e37d18eb2fe6fd7c79526f035c3e9b4cfca0R323-R333