### PR TITLE
Backport Trino Json formatted plan EXPLAIN

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
@@ -49,6 +49,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.sql.ParameterUtils.parameterExtractor;
 import static io.prestosql.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.prestosql.sql.planner.planprinter.IoPlanPrinter.textIoPlan;
+import static io.prestosql.sql.planner.planprinter.PlanPrinter.jsonDistributedPlan;
 import static io.prestosql.sql.planner.planprinter.PlanPrinter.jsonLogicalPlan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -182,6 +183,9 @@ public class QueryExplainer
             case LOGICAL:
                 plan = getLogicalPlan(session, statement, parameters, warningCollector);
                 return jsonLogicalPlan(plan.getRoot(), session, plan.getTypes(), metadata, plan.getStatsAndCosts());
+            case DISTRIBUTED:
+                SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
+                return jsonDistributedPlan(subPlan, metadata, session);
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
@@ -49,6 +49,7 @@ import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.sql.ParameterUtils.parameterExtractor;
 import static io.prestosql.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.prestosql.sql.planner.planprinter.IoPlanPrinter.textIoPlan;
+import static io.prestosql.sql.planner.planprinter.PlanPrinter.jsonLogicalPlan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -173,10 +174,14 @@ public class QueryExplainer
             return explainTask(statement, task, parameters);
         }
 
+        Plan plan;
         switch (planType) {
             case IO:
-                Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
+                plan = getLogicalPlan(session, statement, parameters, warningCollector);
                 return textIoPlan(plan, metadata, typeOperators, session);
+            case LOGICAL:
+                plan = getLogicalPlan(session, statement, parameters, warningCollector);
+                return jsonLogicalPlan(plan.getRoot(), session, plan.getTypes(), metadata, plan.getStatsAndCosts());
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/JsonRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/JsonRenderer.java
@@ -34,7 +34,7 @@ public class JsonRenderer
         return CODEC.toJson(renderJson(plan, plan.getRoot()));
     }
 
-    private JsonRenderedNode renderJson(PlanRepresentation plan, NodeRepresentation node)
+    protected JsonRenderedNode renderJson(PlanRepresentation plan, NodeRepresentation node)
     {
         List<JsonRenderedNode> children = node.getChildren().stream()
                 .map(plan::getNode)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.sql.planner.planprinter;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -151,7 +152,8 @@ public class PlanPrinter
     private final ValuePrinter valuePrinter;
 
     // NOTE: do NOT add Metadata or Session to this class.  The plan printer must be usable outside of a transaction.
-    private PlanPrinter(
+    @VisibleForTesting
+    PlanPrinter(
             PlanNode planRoot,
             TypeProvider types,
             Optional<StageExecutionDescriptor> stageExecutionStrategy,
@@ -189,7 +191,8 @@ public class PlanPrinter
         return new TextRenderer(verbose, level).render(representation);
     }
 
-    private String toJson()
+    @VisibleForTesting
+    String toJson()
     {
         return new JsonRenderer().render(representation);
     }
@@ -203,6 +206,25 @@ public class PlanPrinter
         TableInfoSupplier tableInfoSupplier = new TableInfoSupplier(metadata, session);
         ValuePrinter valuePrinter = new ValuePrinter(metadata, session);
         return new PlanPrinter(root, typeProvider, Optional.empty(), tableInfoSupplier, valuePrinter, StatsAndCosts.empty(), Optional.empty()).toJson();
+    }
+
+    public static String jsonLogicalPlan(
+            PlanNode plan,
+            Session session,
+            TypeProvider types,
+            Metadata metadata,
+            StatsAndCosts estimatedStatsAndCosts)
+    {
+        TableInfoSupplier tableInfoSupplier = new TableInfoSupplier(metadata, session);
+        ValuePrinter valuePrinter = new ValuePrinter(metadata, session);
+        return new PlanPrinter(
+                plan,
+                types,
+                Optional.empty(),
+                tableInfoSupplier,
+                valuePrinter,
+                estimatedStatsAndCosts,
+                Optional.empty()).toJson();
     }
 
     public static String textLogicalPlan(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -66,9 +66,11 @@ import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
 import io.prestosql.sql.planner.plan.OutputNode;
+import io.prestosql.sql.planner.plan.PlanFragmentId;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.PlanNodeId;
 import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.RemoteSourceNode;
 import io.prestosql.sql.planner.plan.RowNumberNode;
 import io.prestosql.sql.planner.plan.SampleNode;
 import io.prestosql.sql.planner.plan.SemiJoinNode;
@@ -1072,6 +1074,15 @@ public class PlanBuilder
                 maxRowCountPerPartition,
                 false,
                 hashSymbol);
+    }
+
+    public RemoteSourceNode remoteSource(
+            List<PlanFragmentId> sourceFragmentIds,
+            List<Symbol> outputs,
+            Optional<OrderingScheme> orderingScheme,
+            ExchangeNode.Type exchangeType)
+    {
+        return new RemoteSourceNode(idAllocator.getNextId(), sourceFragmentIds, outputs, orderingScheme, exchangeType);
     }
 
     public static Expression expression(String sql)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
@@ -17,13 +17,11 @@ package io.prestosql.sql.planner.planprinter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
-import io.prestosql.cost.PlanNodeStatsAndCostSummary;
 import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.execution.TableInfo;
 import io.prestosql.metadata.QualifiedObjectName;
 import io.prestosql.plugin.tpch.TpchConnectorFactory;
 import io.prestosql.spi.predicate.TupleDomain;
-import io.prestosql.sql.planner.OrderingScheme;
 import io.prestosql.sql.planner.PlanNodeIdAllocator;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.iterative.rule.test.PlanBuilder;
@@ -37,10 +35,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.spi.type.BigintType.BIGINT;
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonRepresentation
 {
+    private static final JsonCodec<Map<String, JsonRenderedNode>> DISTRIBUTED_PLAN_JSON_CODEC = mapJsonCodec(String.class, JsonRenderedNode.class);
     private static final JsonCodec<JsonRenderedNode> JSON_RENDERED_NODE_CODEC = jsonCodec(JsonRenderedNode.class);
     private static final TableInfo TABLE_INFO = new TableInfo(
             new QualifiedObjectName("tpch", TINY_SCHEMA_NAME, "orders"),
@@ -68,6 +69,42 @@ public class TestJsonRepresentation
     {
         queryRunner = LocalQueryRunner.create(TEST_SESSION);
         queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+    }
+
+    @Test
+    public void testDistributedJsonPlan()
+    {
+        MaterializedResult actualPlan = queryRunner.execute("EXPLAIN (TYPE DISTRIBUTED, FORMAT JSON) SELECT quantity FROM lineitem limit 10");
+        Map<String, JsonRenderedNode> distributedPlan = ImmutableMap.of(
+                "0", new JsonRenderedNode(
+                        "6",
+                        "Output",
+                        "[quantity]",
+                        "",
+                        ImmutableList.of(new JsonRenderedNode(
+                                "92",
+                                "Limit",
+                                "[10]",
+                                "",
+                                ImmutableList.of(new JsonRenderedNode(
+                                        "141",
+                                        "LocalExchange",
+                                        "[SINGLE] ()",
+                                        "",
+                                        ImmutableList.of(new JsonRenderedNode(
+                                                "0",
+                                                "TableScan",
+                                                "[tpch:lineitem:sf0.01, grouped = false]",
+                                                "quantity := tpch:quantity\n",
+                                                ImmutableList.of(),
+                                                ImmutableList.of())),
+                                        ImmutableList.of())),
+                                ImmutableList.of())),
+                        ImmutableList.of()));
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(742))
+                .row(DISTRIBUTED_PLAN_JSON_CODEC.toJson(distributedPlan))
+                .build();
+        assertThat(actualPlan).isEqualTo(expectedPlan);
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
@@ -1,0 +1,204 @@
+package io.prestosql.sql.planner.planprinter;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.prestosql.cost.PlanNodeStatsAndCostSummary;
+import io.prestosql.cost.StatsAndCosts;
+import io.prestosql.execution.TableInfo;
+import io.prestosql.metadata.QualifiedObjectName;
+import io.prestosql.plugin.tpch.TpchConnectorFactory;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.sql.planner.OrderingScheme;
+import io.prestosql.sql.planner.PlanNodeIdAllocator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.PlanBuilder;
+import io.prestosql.sql.planner.plan.DynamicFilterId;
+import io.prestosql.sql.planner.plan.JoinNode;
+import io.prestosql.sql.planner.plan.PlanFragmentId;
+import io.prestosql.sql.planner.plan.PlanNode;
+import io.prestosql.testing.LocalQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.prestosql.SessionTestUtils.TEST_SESSION;
+import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.VarcharType.createVarcharType;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.prestosql.sql.planner.plan.AggregationNode.Step.FINAL;
+import static io.prestosql.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+import static io.prestosql.sql.planner.planprinter.JsonRenderer.JsonRenderedNode;
+import static io.prestosql.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
+import static io.prestosql.testing.MaterializedResult.resultBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonRepresentation
+{
+    private static final JsonCodec<JsonRenderedNode> JSON_RENDERED_NODE_CODEC = jsonCodec(JsonRenderedNode.class);
+    private static final TableInfo TABLE_INFO = new TableInfo(
+            new QualifiedObjectName("tpch", TINY_SCHEMA_NAME, "orders"),
+            TupleDomain.all());
+
+    private LocalQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = LocalQueryRunner.create(TEST_SESSION);
+        queryRunner.createCatalog(TEST_SESSION.getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+    }
+
+    @Test
+    public void testLogicalJsonPlan()
+    {
+        MaterializedResult actualPlan = queryRunner.execute("EXPLAIN (TYPE LOGICAL, FORMAT JSON) SELECT quantity FROM lineitem limit 10");
+        JsonRenderedNode expectedJsonNode = new JsonRenderedNode(
+                "6",
+                "Output",
+                "[quantity]",
+                "",
+                ImmutableList.of(new JsonRenderedNode(
+                        "92",
+                        "Limit",
+                        "[10]",
+                        "",
+                        ImmutableList.of(new JsonRenderedNode(
+                                "141",
+                                "LocalExchange",
+                                "[SINGLE] ()",
+                                "",
+                                ImmutableList.of(new JsonRenderedNode(
+                                        "0",
+                                        "TableScan",
+                                        "[tpch:lineitem:sf0.01]",
+                                        "quantity := tpch:quantity\n",
+                                        ImmutableList.of(),
+                                        ImmutableList.of())),
+                                ImmutableList.of())),
+                        ImmutableList.of())),
+                ImmutableList.of());
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(657))
+                .row(JSON_RENDERED_NODE_CODEC.toJson(expectedJsonNode))
+                .build();
+        assertThat(actualPlan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void testAggregationPlan()
+    {
+        assertJsonRepresentation(
+                pb -> pb.aggregation(ab -> ab
+                        .step(FINAL)
+                        .addAggregation(pb.symbol("sum", BIGINT), expression("sum(x)"), ImmutableList.of(BIGINT))
+                        .singleGroupingSet(pb.symbol("y", BIGINT), pb.symbol("z", BIGINT))
+                        .source(pb.values(pb.symbol("x", BIGINT), pb.symbol("y", BIGINT), pb.symbol("z", BIGINT)))),
+                new JsonRenderedNode(
+                        "1",
+                        "Aggregate(FINAL)[y, z]",
+                        "",
+                        "sum := sum(\"x\")\n",
+                        ImmutableList.of(valuesRepresentation(
+                                "0",
+                                ImmutableList.of(typedSymbol("x", "bigint"), typedSymbol("y", "bigint"), typedSymbol("z", "bigint")))),
+                        ImmutableList.of()));
+    }
+
+    @Test
+    public void testJoinPlan()
+    {
+        assertJsonRepresentation(
+                pb -> pb.join(
+                        INNER,
+                        pb.values(pb.symbol("a", BIGINT), pb.symbol("b", BIGINT)),
+                        pb.values(pb.symbol("c", BIGINT), pb.symbol("d", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(pb.symbol("a", BIGINT), pb.symbol("d", BIGINT))),
+                        ImmutableList.of(pb.symbol("b", BIGINT)),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableMap.of(new DynamicFilterId("DF"), pb.symbol("d", BIGINT))),
+                new JsonRenderedNode(
+                        "2",
+                        "InnerJoin",
+                        "[(\"a\" = \"d\")]",
+                        "dynamicFilterAssignments = {d -> #DF}",
+                        ImmutableList.of(
+                                valuesRepresentation("0", ImmutableList.of(typedSymbol("a", "bigint"), typedSymbol("b", "bigint"))),
+                                valuesRepresentation("1", ImmutableList.of(typedSymbol("c", "bigint"), typedSymbol("d", "bigint")))),
+                        ImmutableList.of()));
+    }
+
+    @Test
+    public void testSourceFragmentIdsInRemoteSource()
+    {
+        // This test works as a validation to check if descriptor key "sourceFragmentIds" is present
+        // because it is being used to create LivePlan in the prestosql's UI.
+        assertJsonRepresentation(
+                pb -> pb.remoteSource(
+                        ImmutableList.of(new PlanFragmentId("1"), new PlanFragmentId("2")),
+                        ImmutableList.of(pb.symbol("a", BIGINT), pb.symbol("b", BIGINT)),
+                        Optional.empty(),
+                        REPARTITION),
+                new JsonRenderedNode(
+                        "0",
+                        "RemoteSource",
+                        "[1,2]",
+                        "",
+                        ImmutableList.of(),
+                        ImmutableList.of("1", "2")));
+    }
+
+    private static JsonRenderedNode valuesRepresentation(String id, List<TypedSymbol> outputs)
+    {
+        return new JsonRenderedNode(
+                id,
+                "Values",
+                "",
+                "",
+                ImmutableList.of(),
+                ImmutableList.of());
+    }
+
+    private void assertJsonRepresentation(Function<PlanBuilder, PlanNode> sourceNodeSupplier, JsonRenderedNode expectedRepresentation)
+    {
+        PlanBuilder planBuilder = new PlanBuilder(new PlanNodeIdAllocator(), queryRunner.getMetadata());
+        ValuePrinter valuePrinter = new ValuePrinter(queryRunner.getMetadata(), queryRunner.getDefaultSession());
+        PlanPrinter planPrinter = new PlanPrinter(
+                sourceNodeSupplier.apply(planBuilder),
+                planBuilder.getTypes(),
+                Optional.empty(),
+                scanNode -> TABLE_INFO,
+                valuePrinter,
+                StatsAndCosts.empty(),
+                Optional.empty());
+        assertThat(planPrinter.toJson()).isEqualTo(JSON_RENDERED_NODE_CODEC.toJson(expectedRepresentation));
+    }
+
+    public static TypedSymbol typedSymbol(String symbol, String type)
+    {
+        return new TypedSymbol(new Symbol(symbol), type);
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/eventlistener/QueryMetadata.java
@@ -37,6 +37,7 @@ public class QueryMetadata
     private final List<RoutineInfo> routines;
 
     private final Optional<String> plan;
+    private final Optional<String> jsonPlan;
 
     private final Optional<String> payload;
 
@@ -51,6 +52,7 @@ public class QueryMetadata
             List<RoutineInfo> routines,
             URI uri,
             Optional<String> plan,
+            Optional<String> jsonPlan,
             Optional<String> payload)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -63,6 +65,7 @@ public class QueryMetadata
         this.routines = requireNonNull(routines, "routines is null");
         this.uri = requireNonNull(uri, "uri is null");
         this.plan = requireNonNull(plan, "plan is null");
+        this.jsonPlan = requireNonNull(jsonPlan, "jsonPlan is null");
         this.payload = requireNonNull(payload, "payload is null");
     }
 
@@ -124,6 +127,12 @@ public class QueryMetadata
     public Optional<String> getPlan()
     {
         return plan;
+    }
+
+    @JsonProperty
+    public Optional<String> getJsonPlan()
+    {
+        return jsonPlan;
     }
 
     @JsonProperty


### PR DESCRIPTION
Only Trino supports Json formatted EXPLAIN, to store Json EXPLAIN in query completion, we should backport a part of related commits.