### PR TITLE
Fix PREPARE statements with qualified names

### DIFF
--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -34,6 +34,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
`SqlFormatter` internally was using `StringBuilder`, allowing any `Object` to be output, leveraging `Object.toString`. However, many things, especially identifiers and qualified names, require special processing. Identifiers are typically output with
`ExpressionFormatter.formatExpression` and qualified names with `formatName`.  Sometimes these formatting methods were skipped. Previously, such problems were identified one by one, but it seems they were still present in the code base in quite a number. This commit wraps the `StringBuilder` with a custom narrow interface, preventing accidental use of `Object.toString` within `SqlFormatter`.