### PR TITLE
Include output columns in plan json representation

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/JsonRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/JsonRenderer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
 import static java.util.Objects.requireNonNull;
 
 public class JsonRenderer
@@ -47,6 +48,7 @@ public class JsonRenderer
                 node.getId().toString(),
                 node.getName(),
                 node.getIdentifier(),
+                node.getOutputs(),
                 node.getDetails(),
                 children,
                 node.getRemoteSources().stream()
@@ -59,15 +61,24 @@ public class JsonRenderer
         private final String id;
         private final String name;
         private final String identifier;
+        private final List<TypedSymbol> outputs;
         private final String details;
         private final List<JsonRenderedNode> children;
         private final List<String> remoteSources;
 
-        public JsonRenderedNode(String id, String name, String identifier, String details, List<JsonRenderedNode> children, List<String> remoteSources)
+        public JsonRenderedNode(
+                String id,
+                String name,
+                String identifier,
+                List<TypedSymbol> outputs,
+                String details,
+                List<JsonRenderedNode> children,
+                List<String> remoteSources)
         {
             this.id = requireNonNull(id, "id is null");
             this.name = requireNonNull(name, "name is null");
             this.identifier = requireNonNull(identifier, "identifier is null");
+            this.outputs = requireNonNull(outputs, "outputs is null");
             this.details = requireNonNull(details, "details is null");
             this.children = requireNonNull(children, "children is null");
             this.remoteSources = requireNonNull(remoteSources, "id is null");
@@ -89,6 +100,12 @@ public class JsonRenderer
         public String getIdentifier()
         {
             return identifier;
+        }
+
+        @JsonProperty
+        public List<TypedSymbol> getOutputs()
+        {
+            return outputs;
         }
 
         @JsonProperty

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/NodeRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/NodeRepresentation.java
@@ -13,6 +13,8 @@
  */
 package io.prestosql.sql.planner.planprinter;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.prestosql.cost.PlanCostEstimate;
 import io.prestosql.cost.PlanNodeStatsAndCostSummary;
 import io.prestosql.cost.PlanNodeStatsEstimate;
@@ -152,17 +154,20 @@ public class NodeRepresentation
         private final Symbol symbol;
         private final String type;
 
-        public TypedSymbol(Symbol symbol, String type)
+        @JsonCreator
+        public TypedSymbol(@JsonProperty("symbol") Symbol symbol, @JsonProperty("type") String type)
         {
             this.symbol = symbol;
             this.type = type;
         }
 
+        @JsonProperty
         public Symbol getSymbol()
         {
             return symbol;
         }
 
+        @JsonProperty
         public String getType()
         {
             return type;

--- a/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/planprinter/TestJsonRepresentation.java
@@ -80,28 +80,32 @@ public class TestJsonRepresentation
                         "6",
                         "Output",
                         "[quantity]",
+                        ImmutableList.of(typedSymbol("quantity", "double")),
                         "",
                         ImmutableList.of(new JsonRenderedNode(
                                 "92",
                                 "Limit",
                                 "[10]",
+                                ImmutableList.of(typedSymbol("quantity", "double")),
                                 "",
                                 ImmutableList.of(new JsonRenderedNode(
                                         "141",
                                         "LocalExchange",
                                         "[SINGLE] ()",
+                                        ImmutableList.of(typedSymbol("quantity", "double")),
                                         "",
                                         ImmutableList.of(new JsonRenderedNode(
                                                 "0",
                                                 "TableScan",
                                                 "[tpch:lineitem:sf0.01, grouped = false]",
+                                                ImmutableList.of(typedSymbol("quantity", "double")),
                                                 "quantity := tpch:quantity\n",
                                                 ImmutableList.of(),
                                                 ImmutableList.of())),
                                         ImmutableList.of())),
                                 ImmutableList.of())),
                         ImmutableList.of()));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(742))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1118))
                 .row(DISTRIBUTED_PLAN_JSON_CODEC.toJson(distributedPlan))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);
@@ -115,28 +119,32 @@ public class TestJsonRepresentation
                 "6",
                 "Output",
                 "[quantity]",
+                ImmutableList.of(typedSymbol("quantity", "double")),
                 "",
                 ImmutableList.of(new JsonRenderedNode(
                         "92",
                         "Limit",
                         "[10]",
+                        ImmutableList.of(typedSymbol("quantity", "double")),
                         "",
                         ImmutableList.of(new JsonRenderedNode(
                                 "141",
                                 "LocalExchange",
                                 "[SINGLE] ()",
+                                ImmutableList.of(typedSymbol("quantity", "double")),
                                 "",
                                 ImmutableList.of(new JsonRenderedNode(
                                         "0",
                                         "TableScan",
                                         "[tpch:lineitem:sf0.01]",
+                                        ImmutableList.of(typedSymbol("quantity", "double")),
                                         "quantity := tpch:quantity\n",
                                         ImmutableList.of(),
                                         ImmutableList.of())),
                                 ImmutableList.of())),
                         ImmutableList.of())),
                 ImmutableList.of());
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(657))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1001))
                 .row(JSON_RENDERED_NODE_CODEC.toJson(expectedJsonNode))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);
@@ -155,6 +163,10 @@ public class TestJsonRepresentation
                         "1",
                         "Aggregate(FINAL)[y, z]",
                         "",
+                        ImmutableList.of(
+                                typedSymbol("y", "bigint"),
+                                typedSymbol("z", "bigint"),
+                                typedSymbol("sum", "bigint")),
                         "sum := sum(\"x\")\n",
                         ImmutableList.of(valuesRepresentation(
                                 "0",
@@ -181,6 +193,7 @@ public class TestJsonRepresentation
                         "2",
                         "InnerJoin",
                         "[(\"a\" = \"d\")]",
+                        ImmutableList.of(typedSymbol("b", "bigint")),
                         "dynamicFilterAssignments = {d -> #DF}",
                         ImmutableList.of(
                                 valuesRepresentation("0", ImmutableList.of(typedSymbol("a", "bigint"), typedSymbol("b", "bigint"))),
@@ -203,6 +216,7 @@ public class TestJsonRepresentation
                         "0",
                         "RemoteSource",
                         "[1,2]",
+                        ImmutableList.of(typedSymbol("a", "bigint"), typedSymbol("b", "bigint")),
                         "",
                         ImmutableList.of(),
                         ImmutableList.of("1", "2")));
@@ -214,6 +228,7 @@ public class TestJsonRepresentation
                 id,
                 "Values",
                 "",
+                outputs,
                 "",
                 ImmutableList.of(),
                 ImmutableList.of());


### PR DESCRIPTION
backported c484ba21f7162466b94c9359e7f1553cc1ef5967 