### PR TITLE
Use CircleCI context instead of environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 aliases:
   - &install_jdk
@@ -71,5 +72,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,9 @@ workflows:
   build_and_integration:
     jobs:
       - build_and_deploy:
+          context:
+            - aws-td
+            - jfrog
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,7 @@ jobs:
       - run: *install_jdk
 
       - run:
-          name: Debug
-          command: |
-            echo $MAVEN_OPTS | base64
-
-      - run:
           name: Build presto
-          # environment:
-          #   MAVEN_OPTS: "true"
           command: |
             # Assign a unique version number to the modules
             rake update-pom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ jobs:
 
       - run:
           name: Build presto
-          environment:
-            MAVEN_OPTS: "true"
+          # environment:
+          #   MAVEN_OPTS: "true"
           command: |
             # Assign a unique version number to the modules
             rake update-pom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,14 @@ jobs:
       - run: *install_jdk
 
       - run:
+          name: Debug
+          command: |
+            echo $MAVEN_OPTS | base64
+
+      - run:
           name: Build presto
+          environment:
+            MAVEN_OPTS: "true"
           command: |
             # Assign a unique version number to the modules
             rake update-pom


### PR DESCRIPTION
## Tasks

- [x] Drop the below environment variables in the following page after merging this PR
       https://app.circleci.com/settings/project/github/treasure-data/presto/environment-variables
       
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - TD_ARTIFACTORY_PASSWORD
       - TD_ARTIFACTORY_USERNAME
       - (extra) MAVEN_OPTS 🆕 