### PR TITLE
Desugar in evaluateConstantExpression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -3459,6 +3459,37 @@ public class ExpressionAnalyzer
                 analyzer.getWindowFunctions());
     }
 
+    public static void analyzeExpressionWithoutSubqueries(
+            Session session,
+            PlannerContext plannerContext,
+            AccessControl accessControl,
+            Scope scope,
+            Analysis analysis,
+            Expression expression,
+            ErrorCodeSupplier errorCode,
+            String message,
+            WarningCollector warningCollector,
+            CorrelationSupport correlationSupport)
+    {
+        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(
+                plannerContext,
+                accessControl,
+                (node, ignored) -> {
+                    throw semanticException(errorCode, node, message);
+                },
+                session,
+                TypeProvider.empty(),
+                analysis.getParameters(),
+                warningCollector,
+                analysis.isDescribe(),
+                analysis::getType,
+                analysis::getWindow);
+        analyzer.analyze(expression, scope, correlationSupport);
+
+        updateAnalysis(analysis, analyzer, session, accessControl);
+        analysis.addExpressionFields(expression, analyzer.getSourceFields());
+    }
+
     public static ExpressionAnalysis analyzeWindow(
             Session session,
             PlannerContext plannerContext,


### PR DESCRIPTION
Use TranslationMap to apply casts, desugar expression, and preform other rewrites in evaluateConstantExpression